### PR TITLE
fix(RestWrite): make method async as expected in usage

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -872,7 +872,7 @@ RestWrite.prototype.createSessionTokenIfNeeded = function() {
   return this.createSessionToken();
 };
 
-RestWrite.prototype.createSessionToken = function() {
+RestWrite.prototype.createSessionToken = async function() {
   // cloud installationId from Cloud Code,
   // never create session tokens from there.
   if (this.auth.installationId && this.auth.installationId === 'cloud') {


### PR DESCRIPTION
The method `createSessionToken` in RestWrite.js is assumed to always return a promise (see Line 961 in `handleFollowUp`) - this was throwing an error `cannot read 'then' of undefined`. This simply one word change fixes that error.